### PR TITLE
Update commands and sub-commands to use a standard print style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,22 @@
+target
 cli/dependency-reduced-pom.xml
-/docs/target/
-/maven-resolver/target/
-/tests/glow-tests/target/
-/core/target/
-/cli/target/
-/tests/test-feature-pack/layer-metadata-tests/target/
-/tests/test-feature-pack/galleon-pack/target/
-/arquillian-plugin/target/
-/tests/test-feature-pack/test-classes/target/
-/tests/arquillian-plugin-tests/target/
-/arquillian-plugin-scanner/target/
-tests/.env
-.idea
+
+# Intellij
 *.iml
+*.ipr
+*.iws
+.idea
+
+# Eclipse
+**/.settings
+**/.project
+**/.classpath
+**/.checkstyle
+**/.factorypath
+
+# VS Code
+**/.vscode/
+
+# macOS Files
+.DS_Store
+

--- a/cli/src/main/java/org/wildfly/glow/cli/ExecutionExceptionHandler.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/ExecutionExceptionHandler.java
@@ -17,6 +17,7 @@
 
 package org.wildfly.glow.cli;
 
+import org.wildfly.glow.cli.commands.AbstractCommand;
 import picocli.CommandLine;
 
 
@@ -25,18 +26,20 @@ import picocli.CommandLine;
  */
 public class ExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
 
+    private final AbstractCommand command;
     private final boolean isVerbose;
 
-    public ExecutionExceptionHandler(boolean isVerbose) {
+    public ExecutionExceptionHandler(boolean isVerbose, AbstractCommand command) {
         this.isVerbose = isVerbose;
+        this.command = command;
     }
 
     @Override
     public int handleExecutionException(Exception ex, CommandLine commandLine, CommandLine.ParseResult parseResult)
             throws Exception {
-        System.err.println(CommandLine.Help.Ansi.AUTO.string("@|fg(red) ERROR: " + ex.getLocalizedMessage() + "|@"));
+        command.printError("ERROR: %s",  ex.getLocalizedMessage());
         if(isVerbose) {
-            ex.printStackTrace();
+            ex.printStackTrace(command.getStderr());
         }
         return 1;
     }

--- a/cli/src/main/java/org/wildfly/glow/cli/GlowCLI.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/GlowCLI.java
@@ -30,6 +30,7 @@ import org.wildfly.glow.Layer;
 import org.wildfly.glow.LayerMapping;
 import org.wildfly.glow.ScanResults;
 import org.wildfly.glow.Utils;
+import org.wildfly.glow.cli.commands.AbstractCommand;
 import org.wildfly.glow.maven.MavenResolver;
 
 import java.util.Collections;
@@ -59,8 +60,9 @@ import picocli.CommandLine;
 public class GlowCLI {
 
     public static void main(String[] args) throws Exception {
+        final AbstractCommand command = new MainCommand();
         try {
-            CommandLine commandLine = new CommandLine(new MainCommand());
+            CommandLine commandLine = new CommandLine(command);
             commandLine.addSubcommand(new ScanCommand());
             commandLine.addSubcommand(new ShowAddOnsCommand());
             commandLine.addSubcommand(new ShowServerVersionsCommand());
@@ -69,7 +71,7 @@ public class GlowCLI {
             commandLine.addSubcommand(new CompletionCommand());
             commandLine.setUsageHelpAutoWidth(true);
             final boolean isVerbose = Arrays.stream(args).anyMatch(s -> s.equals("-vv") || s.equals("--verbose"));
-            commandLine.setExecutionExceptionHandler(new ExecutionExceptionHandler(isVerbose));
+            commandLine.setExecutionExceptionHandler(new ExecutionExceptionHandler(isVerbose, command));
             int exitCode = commandLine.execute(args);
             System.exit(exitCode);
         } catch (Exception ex) {
@@ -78,7 +80,7 @@ public class GlowCLI {
         }
         CLIArguments arguments = CLIArguments.fromMainArguments(args);
         if (arguments.isVersion()) {
-           System.out.println(Version.getVersion());
+           command.print(Version.getVersion());
            return;
         }
         boolean dumpInfos = args.length == 0 || arguments.isHelp();

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/Constants.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/Constants.java
@@ -36,6 +36,9 @@ public interface Constants {
     String ADD_ONS_OPTION_LABEL = "<add-on>";
     String ADD_ONS_OPTION_SHORT = "-ao";
 
+    String BATCH_OPTION = "--batch";
+    String BATCH_OPTION_SHORT = "-B";
+
     String CLOUD_OPTION = "--cloud";
     String CLOUD_OPTION_SHORT = "-c";
     String DOCKER_IMAGE_NAME_OPTION = "--docker-image-name";

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/GoOfflineCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/GoOfflineCommand.java
@@ -34,9 +34,6 @@ import picocli.CommandLine;
 )
 public class GoOfflineCommand extends AbstractCommand {
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
-
     @CommandLine.Option(names = {Constants.CLOUD_OPTION_SHORT, Constants.CLOUD_OPTION})
     Optional<Boolean> cloud;
 
@@ -51,7 +48,7 @@ public class GoOfflineCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println("Wildfly Glow is assembling offline content...");
+        print("Wildfly Glow is assembling offline content...");
         Builder builder = Arguments.scanBuilder();
         if (cloud.orElse(false)) {
             builder.setExecutionContext(CLOUD_EXECUTION_CONTEXT);
@@ -62,14 +59,12 @@ public class GoOfflineCommand extends AbstractCommand {
         if (wildflyServerVersion.isPresent()) {
             builder.setVersion(wildflyServerVersion.get());
         }
-        if (verbose.isPresent()) {
-            builder.setVerbose(verbose.get());
-        }
+        builder.setVerbose(verbose);
         if (provisioningXml.isPresent()) {
             builder.setProvisoningXML(provisioningXml.get());
         }
         GlowSession.goOffline(MavenResolver.newMavenResolver(), builder.build(), GlowMessageWriter.DEFAULT);
-        System.out.println("Offline zip file "+ OFFLINE_ZIP + " generated");
+        print("Offline zip file %s generated", OFFLINE_ZIP);
         return 0;
     }
 }

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/MainCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/MainCommand.java
@@ -16,41 +16,26 @@
  */
 package org.wildfly.glow.cli.commands;
 
-import java.io.IOException;
 import java.util.ResourceBundle;
-import java.util.concurrent.Callable;
 import org.wildfly.glow.Version;
 
 import picocli.CommandLine;
 
 @CommandLine.Command(name = Constants.WILDFLY_GLOW, resourceBundle = "UsageMessages",
         versionProvider = MainCommand.VersionProvider.class)
-public class MainCommand implements Callable<Integer> {
-
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
-
-
-    @SuppressWarnings("unused")
-    @CommandLine.Option(names = {Constants.HELP_OPTION_SHORT, Constants.HELP_OPTION}, usageHelp = true)
-    boolean help;
+public class MainCommand extends AbstractCommand {
 
     @SuppressWarnings("unused")
     @CommandLine.Option(names = {Constants.VERSION_OPTION_SHORT, Constants.VERSION_OPTION}, versionHelp = true)
     boolean version;
 
-    @SuppressWarnings("unused")
-    @CommandLine.Option(names = {Constants.VERBOSE_OPTION_SHORT, Constants.VERBOSE_OPTION})
-    boolean verbose;
-
     @Override
-    public Integer call() throws IOException {
+    public Integer call() {
+        spec.commandLine().usage(System.out);
         // print welcome message - this is not printed when -h option is set
         ResourceBundle usageBundle = ResourceBundle.getBundle("UsageMessages");
 
-        System.out.println(CommandLine.Help.Ansi.AUTO.string(usageBundle.getString("glow.welcomeMessage")));
-        // print main command usage
-        spec.commandLine().usage(System.out);
+        print(usageBundle.getString("glow.welcomeMessage"));
         return 0;
     }
 

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/ScanCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/ScanCommand.java
@@ -49,9 +49,6 @@ import picocli.CommandLine.Parameters;
 )
 public class ScanCommand extends AbstractCommand {
 
-    @CommandLine.Spec
-    protected CommandLine.Model.CommandSpec spec;
-
     @CommandLine.Option(names = {Constants.CLOUD_OPTION_SHORT, Constants.CLOUD_OPTION})
     Optional<Boolean> cloud;
 
@@ -90,7 +87,7 @@ public class ScanCommand extends AbstractCommand {
         HiddenPropertiesAccessor hiddenPropertiesAccessor = new HiddenPropertiesAccessor();
         boolean compact = Boolean.parseBoolean(hiddenPropertiesAccessor.getProperty(COMPACT_PROPERTY));
         if (!compact) {
-            System.out.println("Wildfly Glow is scanning...");
+            print("Wildfly Glow is scanning...");
         }
         Builder builder = Arguments.scanBuilder();
         if (cloud.orElse(false)) {
@@ -113,9 +110,7 @@ public class ScanCommand extends AbstractCommand {
         if (wildflyServerVersion.isPresent()) {
             builder.setVersion(wildflyServerVersion.get());
         }
-        if (verbose.isPresent()) {
-            builder.setVerbose(verbose.get());
-        }
+        builder.setVerbose(verbose);
         if (!addOns.isEmpty()) {
             builder.setUserEnabledAddOns(addOns);
         }
@@ -145,58 +140,58 @@ public class ScanCommand extends AbstractCommand {
             if (!compact) {
                 if (suggest.orElse(false)) {
                     if (!scanResults.getSuggestions().getPossibleAddOns().isEmpty() && addOns.isEmpty()) {
-                        System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold To enable add-ons add the|@ @|fg(yellow) " + Constants.ADD_ONS_OPTION + "=<list of add-ons>|@ @|bold option to the|@ @|fg(yellow) " + Constants.SCAN_COMMAND + "|@ @|bold command|@"));
+                        print("@|bold To enable add-ons add the|@ @|fg(yellow) %s=<list of add-ons>|@ @|bold option to the|@ @|fg(yellow) %s|@ @|bold command|@", Constants.ADD_ONS_OPTION, Constants.SCAN_COMMAND);
                     }
                     if (!scanResults.getSuggestions().getPossibleProfiles().isEmpty()) {
-                        System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold To enable the HA profile add the|@ @|fg(yellow) " + Constants.HA_OPTION + "|@ @|bold option to the|@ @|fg(yellow) " + Constants.SCAN_COMMAND + "|@ @|bold command|@"));
+                        print("@|bold To enable the HA profile add the|@ @|fg(yellow) %s|@ @|bold option to the|@ @|fg(yellow) %s|@ @|bold command|@", Constants.HA_OPTION, Constants.SCAN_COMMAND);
                     }
                 }
-                System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold To provision the WildFly server for your deployment add the|@ @|fg(yellow) " + Constants.PROVISION_OPTION + "=SERVER|@ @|bold option to the|@ @|fg(yellow) " + Constants.SCAN_COMMAND + "|@ @|bold command|@"));
+                print("@|bold To provision the WildFly server for your deployment add the|@ @|fg(yellow) %s=SERVER|@ @|bold option to the|@ @|fg(yellow) %s|@ @|bold command|@", Constants.PROVISION_OPTION, Constants.SCAN_COMMAND);
             }
         } else {
-            System.out.print("\n");
+            print();
             Path target = null;
             String vers = wildflyServerVersion.orElse(null) == null ? FeaturePacks.getLatestVersion() : wildflyServerVersion.get();
             String doneMessage = null;
             switch (provision.get()) {
                 case BOOTABLE_JAR: {
                     target = Paths.get("");
-                    System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Building WildFly Bootable JAR file|@"));
+                    print("@|bold Building WildFly Bootable JAR file|@");
                     break;
                 }
                 case PROVISIONING_XML: {
                     target = Paths.get("server-" + vers);
-                    System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Generating provisioning configuration in " + target + "/provisioning.xml file|@"));
-                    doneMessage = CommandLine.Help.Ansi.AUTO.string("@|bold Generation DONE. Provisioning configuration is located in " + target + "/provisioning.xml file|@");
+                    print("@|bold Generating provisioning configuration in %s/provisioning.xml file|@", target);
+                    doneMessage = "@|bold Generation DONE. Provisioning configuration is located in " + target + "/provisioning.xml file|@";
                     break;
                 }
                 case SERVER: {
                     target = Paths.get("server-" + vers);
-                    System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Provisioning server in " + target + " directory|@"));
+                    print("@|bold Provisioning server in %s directory|@", target);
                     if (cloud.orElse(false)) {
-                        doneMessage = CommandLine.Help.Ansi.AUTO.string("@|bold Provisioning DONE. To run the server: 'JBOSS_HOME=" + target + " sh " + target + "/bin/openshift-launch.sh'|@");
+                        doneMessage = "@|bold Provisioning DONE. To run the server: 'JBOSS_HOME=" + target + " sh " + target + "/bin/openshift-launch.sh'|@";
                     } else {
-                        doneMessage = CommandLine.Help.Ansi.AUTO.string("@|bold Provisioning DONE. To run the server: 'sh " + target + "/bin/standalone.sh'|@");
+                        doneMessage = "@|bold Provisioning DONE. To run the server: 'sh " + target + "/bin/standalone.sh'|@";
                     }
                     break;
                 }
                 case DOCKER_IMAGE: {
                     target = Paths.get("server-" + vers);
                     String imageName = dockerImageName.isPresent()? dockerImageName.get() : DockerSupport.getImageName(target.toString());
-                    System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Generating docker image '" + imageName + "'|@"));
-                    doneMessage = CommandLine.Help.Ansi.AUTO.string("@|bold To run the image call: 'docker run " + imageName + "'|@");
+                    print("@|bold Generating docker image '%s'|@", imageName);
+                    doneMessage = "@|bold To run the image call: 'docker run " + imageName + "'|@";
                     break;
                 }
             }
             Path actualTarget = scanResults.outputConfig(target, dockerImageName.orElse(null));
             if (BOOTABLE_JAR.equals(provision.get())) {
-                doneMessage = CommandLine.Help.Ansi.AUTO.string("@|bold Bootable JAR build DONE. To run the jar: 'java -jar " + actualTarget + "'|@");
+                doneMessage = "@|bold Bootable JAR build DONE. To run the jar: 'java -jar " + actualTarget + "'|@";
             } else {
                 if (DOCKER_IMAGE.equals(provision.get())) {
-                    System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Image generation DONE. Docker file generated in " + actualTarget.toAbsolutePath() + "|@."));
+                    print("@|bold Image generation DONE. Docker file generated in %s|@.", actualTarget.toAbsolutePath());
                 }
             }
-            System.out.println(doneMessage);
+            print(doneMessage);
         }
         return 0;
     }

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/ShowAddOnsCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/ShowAddOnsCommand.java
@@ -56,7 +56,7 @@ public class ShowAddOnsCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println("Wildfly Glow is retrieving add-ons...");
+        print("Wildfly Glow is retrieving add-ons...");
         MavenRepoManager resolver = MavenResolver.newMavenResolver();
         UniverseResolver universeResolver = UniverseResolver.builder().addArtifactResolver(resolver).build();
         String context = Arguments.BARE_METAL_EXECUTION_CONTEXT;
@@ -74,15 +74,15 @@ public class ShowAddOnsCommand extends AbstractCommand {
             LayerMapping mapping = Utils.buildMapping(all, Collections.emptySet());
             StringBuilder builder = new StringBuilder();
             for (Map.Entry<String, Set<AddOn>> entry : mapping.getAddOnFamilyMembers().entrySet()) {
-                builder.append("* @|bold ").append(entry.getKey()).append("|@ add-ons:\n");
+                builder.append("* @|bold ").append(entry.getKey()).append("|@ add-ons:%n");
                 for (AddOn member : mapping.getAddOnFamilyMembers().get(entry.getKey())) {
                     if (!member.getName().endsWith(":default")) {
-                        builder.append(" - ").append(member.getName()).append(member.getDescription() == null ? "" : ": " + member.getDescription()).append("\n");
+                        builder.append(" - ").append(member.getName()).append(member.getDescription() == null ? "" : ": " + member.getDescription()).append("%n");
                     }
                 }
             }
-            System.out.println(CommandLine.Help.Ansi.AUTO.string(builder.toString()));
-            System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold Add-ons can be set using the|@ @|fg(yellow) " + Constants.ADD_ONS_OPTION + "=<list of add-ons>|@ @|bold option of the|@ @|fg(yellow) " + Constants.SCAN_COMMAND + "|@ @|bold command|@"));
+            print(builder.toString());
+            print("@|bold Add-ons can be set using the|@ @|fg(yellow) %s=<list of add-ons>|@ @|bold option of the|@ @|fg(yellow) %s|@ @|bold command|@", Constants.ADD_ONS_OPTION, Constants.SCAN_COMMAND);
         }
         return 0;
     }

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/ShowConfigurationCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/ShowConfigurationCommand.java
@@ -60,7 +60,7 @@ public class ShowConfigurationCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println("Wildfly Glow is retrieving know provisioning configuration...");
+        print("Wildfly Glow is retrieving know provisioning configuration...");
         MavenRepoManager resolver = MavenResolver.newMavenResolver();
         UniverseResolver universeResolver = UniverseResolver.builder().addArtifactResolver(resolver).build();
         String context = Arguments.BARE_METAL_EXECUTION_CONTEXT;
@@ -82,7 +82,7 @@ public class ShowConfigurationCommand extends AbstractCommand {
             Path fps = FeaturePacks.getFeaturePacks(vers, context, wildflyPreview.orElse(false));
             ProvisioningConfig config = ProvisioningXmlParser.parse(fps);
             String configStr = CLIArguments.dumpConfiguration(fpDependencies, context, vers, all, mapping, config, isLatest, wildflyPreview.orElse(false));
-            System.out.println(CommandLine.Help.Ansi.AUTO.string(configStr));
+            print(configStr);
         }
         return 0;
     }

--- a/cli/src/main/java/org/wildfly/glow/cli/commands/ShowServerVersionsCommand.java
+++ b/cli/src/main/java/org/wildfly/glow/cli/commands/ShowServerVersionsCommand.java
@@ -27,8 +27,8 @@ public class ShowServerVersionsCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println(FeaturePacks.getAllVersions());
-        System.out.println(CommandLine.Help.Ansi.AUTO.string("@|bold WildFly server version can be set using the|@ @|fg(yellow) "+Constants.SERVER_VERSION_OPTION+"=<server version>|@ @|bold option of the|@ @|fg(yellow) "+Constants.SCAN_COMMAND+"|@ @|bold command|@"));
+        print(FeaturePacks.getAllVersions());
+        print("@|bold WildFly server version can be set using the|@ @|fg(yellow) %s=<server version>|@ @|bold option of the|@ @|fg(yellow) %s|@ @|bold command|@", Constants.SERVER_VERSION_OPTION, Constants.SCAN_COMMAND);
         return 0;
     }
 }

--- a/cli/src/main/resources/UsageMessages.properties
+++ b/cli/src/main/resources/UsageMessages.properties
@@ -17,7 +17,7 @@ glow.welcomeMessage = @|bold \nWelcome to WildFly Glow CLI!|@\n\
 
 wildfly-glow.usage.footer = %nUse @|fg(yellow) wildfly-glow <command> --help|@ to show help information for the command.
 
-
+batch = Batch mode disables any colorization of the output.
 cloud = When deploying your application to the cloud. It will fine tune the WildFly server for the cloud. N.B.: Building a Bootable JAR is not supported for the cloud.
 docker-image-name = Name of the docker image when --provision=DOCKER is specified. By default an image name is computed based on the WildFly server version.
 version = Prints the version of wildfly-glow and exits.


### PR DESCRIPTION
This PR mostly updates the commands to use a defined `print()` style in the `AbstractCommand`. This allows the colorized output to be disabled for environments like CI.