### PR TITLE
Fix for Issue #128, Bootable JAR packaging broken with preview/experimental stability level

### DIFF
--- a/core/src/main/java/org/wildfly/glow/EnvHandler.java
+++ b/core/src/main/java/org/wildfly/glow/EnvHandler.java
@@ -19,8 +19,6 @@ package org.wildfly.glow;
 
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +31,7 @@ import java.util.TreeSet;
  */
 public class EnvHandler {
 
-    public static Set<Env> retrieveEnv(URI uri) throws MalformedURLException, IOException {
+    public static Set<Env> retrieveEnv(URI uri) {
         Set<Env> ret = new TreeSet<>();
         try {
             Yaml yaml = new Yaml();
@@ -48,7 +46,7 @@ public class EnvHandler {
                 Boolean property = (Boolean) env.get("property");
                 ret.add(new Env(name,description, buildTime, required, property));
             }
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
             System.err.println("Error accessing configuration in " + uri);
         }

--- a/core/src/main/java/org/wildfly/glow/EnvHandler.java
+++ b/core/src/main/java/org/wildfly/glow/EnvHandler.java
@@ -49,6 +49,7 @@ public class EnvHandler {
                 ret.add(new Env(name,description, buildTime, required, property));
             }
         } catch (IOException ex) {
+            ex.printStackTrace();
             System.err.println("Error accessing configuration in " + uri);
         }
         return ret;

--- a/core/src/main/java/org/wildfly/glow/GlowSession.java
+++ b/core/src/main/java/org/wildfly/glow/GlowSession.java
@@ -74,6 +74,9 @@ import org.wildfly.plugin.tools.bootablejar.BootableJarSupport;
  * @author jdenise
  */
 public class GlowSession {
+    // Used when starting an embedded server
+    public static final String MINIMAL_STABILITY_LEVEL = "experimental";
+
     public static final Path OFFLINE_ZIP = Paths.get("glow-offline.zip");
     public static final Path OFFLINE_CONTENT = Paths.get("glow-offline-content");
     public static final Path OFFLINE_DOCS_DIR = OFFLINE_CONTENT.resolve("docs");
@@ -868,7 +871,7 @@ public class GlowSession {
                     public void close() throws Exception {
                     }
 
-                });
+                },  MINIMAL_STABILITY_LEVEL);
             }
         } finally {
             if (tmpDir != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.info.picocli>4.7.5</version.info.picocli>
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.biz.aQute.bnd>6.4.0</version.biz.aQute.bnd>
-        <version.org.wildfly.plugins.wildfly-plugin-tools>1.2.0.Final</version.org.wildfly.plugins.wildfly-plugin-tools>
+        <version.org.wildfly.plugins.wildfly-plugin-tools>1.2.3.Final</version.org.wildfly.plugins.wildfly-plugin-tools>
         <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
         <version.com.puppycrawl.tools.checkstyle>8.18</version.com.puppycrawl.tools.checkstyle>
         <version.com.fasterxml.jackson.core>2.17.2</version.com.fasterxml.jackson.core>


### PR DESCRIPTION
Provide a minimal stability level to allow for CLI executed during packaging to succeed when FP in the provisioning config include content at a lower level.
Closes #128 
