### PR TITLE
docs: fix broken link in incubating feature-packs section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -565,7 +565,7 @@ that are bound to the usage of a given Galleon Layer. An example of rule can be 
 <p>Feature-packs that are developed outside of the WildFly feature process can be registered in the "incubating" space.
 This space can be explicitly enabled when discovering provisioning configuration.
 WildFly Glow has, per WildFly version, the knowledge of 'incubating' compatible Galleon Feature-packs (this information is stored in
-<a href="https://github.com/wildfly/wildfly-galleon-feature-packs/tree/main/spaces/incubating">this</a> directory).</p>
+<a href="https://github.com/wildfly/wildfly-galleon-feature-packs/tree/release/spaces/incubating">this</a> directory).</p>
 </div>
 <div class="paragraph">
 <p>In order for these extras feature-packs to be recognized by WildFly Glow, they must have their defined Layers annotated with rules.</p>


### PR DESCRIPTION
Please check the link for a detailed explanation of the issue.

docs: fix broken link in incubating feature-packs section #153
